### PR TITLE
Implement atproto verify credentials

### DIFF
--- a/src/routes/_actions/accounts.js
+++ b/src/routes/_actions/accounts.js
@@ -3,7 +3,7 @@ import { getRelationship as getApRelationship } from '../_api/relationships.js'
 import atprotoAgent from '../_api_atproto/agent.js'
 import { database } from '../_database/database.js'
 import { store } from '../_store/store.js'
-import { transformProfileViewToEnaforeAccount } from '../_api_atproto/timelines.js' // Assuming a suitable transformer
+import { transformProfileViewToEnaforeAccount } from '../_api_atproto/posts.js'
 
 // Helper to determine if an ID is a DID (very basic check)
 function isDid (id) {
@@ -108,8 +108,8 @@ async function _updateRelationship (accountId, instanceName, accessToken) {
     } catch (e) {
       console.error(e)
     }
-    try {
-      store.set({ currentAccountRelationship: (await remotePromise) })
+  try {
+    store.set({ currentAccountRelationship: await remotePromise })
   } catch (e) {
     console.error(e)
   }

--- a/src/routes/_store/mixins/atprotoMixins.js
+++ b/src/routes/_store/mixins/atprotoMixins.js
@@ -2,9 +2,11 @@ import atprotoAgent, { setPdsUrl as setAgentPdsUrl, getPdsUrl as getAgentPdsUrl 
 import * as atprotoAPI from '../_api_atproto/auth.js' // Keep consistent with other API imports
 import * as atprotoNotificationsAPI from '../_api_atproto/notifications.js' // For notifications
 import * as atprotoPostsApi from '../_api_atproto/posts.js' // For getPostLikes, getPostReposters
+import { transformProfileViewToEnaforeAccount } from '../_api_atproto/posts.js'
 import { setAtprotoAccount, getAtprotoAccount } from '../_database/atprotoAccounts.js'
 import { setAtprotoPost, getAtprotoPost } from '../_database/atprotoPosts.js' // For persisting like/repost states
 import { setAtprotoNotifications } from '../_database/atprotoNotifications.js' // For saving notifications
+import { setInstanceVerifyCredentials } from '../_database/meta.js'
 import { toast } from '../../_components/toast/toast.js' // For user feedback on bookmark actions
 import { database } from '../_database/database.js' // For getAtprotoFeedCursor, setAtprotoFeedCursor
 import { BskyAgent } from '@atproto/api' // For fetching profile after login
@@ -16,7 +18,7 @@ export function atprotoMixins (Store) {
     let sessionData
     try {
       // Ensure agent's PDS URL is set before login
-      const effectivePdsUrl = pdsUrl || this.get().atprotoPdsUrls[identifier] || (typeof localStorage !== 'undefined' && localStorage.getItem('atproto_pds_url')) ||'https://bsky.social'
+      const effectivePdsUrl = pdsUrl || this.get().atprotoPdsUrls[identifier] || (typeof localStorage !== 'undefined' && localStorage.getItem('atproto_pds_url')) || 'https://bsky.social'
       if (getAgentPdsUrl() !== effectivePdsUrl) {
         console.log(`[Store Mixin] Setting agent PDS URL to: ${effectivePdsUrl}`)
         setAgentPdsUrl(effectivePdsUrl)
@@ -26,12 +28,18 @@ export function atprotoMixins (Store) {
       console.log(`[Store Mixin] atprotoLogin API success for DID: ${sessionData.did}`)
 
       // After successful login, fetch and store the user's profile
+      let transformedProfile
       try {
         // Use the main agent which now has the session
         const profile = await atprotoAgent.getProfile({ actor: sessionData.did })
         if (profile && profile.data) {
-          await setAtprotoAccount(new URL(getAgentPdsUrl()).hostname, profile.data)
-          console.log(`[Store Mixin] User profile for ${sessionData.did} stored in DB.`)
+          const pdsHost = new URL(getAgentPdsUrl()).hostname
+          await setAtprotoAccount(pdsHost, profile.data)
+          transformedProfile = transformProfileViewToEnaforeAccount(profile.data, pdsHost)
+          await setInstanceVerifyCredentials(pdsHost, transformedProfile)
+          const vc = { ...this.get().verifyCredentials, [pdsHost]: transformedProfile }
+          this.set({ verifyCredentials: vc })
+          console.log(`[Store Mixin] User profile for ${sessionData.did} stored in DB and set as verifyCredentials.`)
         }
       } catch (profileError) {
         console.error(`[Store Mixin] Failed to fetch or store profile for ${sessionData.did} after login:`, profileError)
@@ -44,6 +52,7 @@ export function atprotoMixins (Store) {
       const newAtprotoPdsUrls = { ...this.get().atprotoPdsUrls }
       newAtprotoPdsUrls[sessionData.did] = getAgentPdsUrl()
 
+      const vcMap = transformedProfile ? { ...this.get().verifyCredentials, [new URL(getAgentPdsUrl()).hostname]: transformedProfile } : this.get().verifyCredentials
       this.set({
         atprotoSessions: newAtprotoSessions,
         currentAtprotoSessionDid: sessionData.did,
@@ -54,8 +63,8 @@ export function atprotoMixins (Store) {
         currentAccountProtocol: 'atproto',
         currentInstance: new URL(getAgentPdsUrl()).hostname, // Set currentInstance to PDS hostname
         // Clear other ActivityPub active state if they were distinct
-        currentRegisteredInstanceName: null, // This was for AP OAuth flow state
-        // accessToken: null, // Assuming accessToken is AP specific and not in global store root here
+        currentRegisteredInstanceName: null,
+        verifyCredentials: vcMap
         // apNotificationItems: [],
         // apUnreadNotificationCount: 0,
         // For now, focusing on core instance/session identifiers.
@@ -66,17 +75,17 @@ export function atprotoMixins (Store) {
       console.error('[Store Mixin] atprotoLogin error:', err.message, err)
       // If login fails, sessionData might be undefined.
       // If it was a PDS connection issue, sessionData.did might not exist.
-      const failedLoginIdentifier = sessionData?.did || identifier;
-      const pdsHostForFailedLogin = new URL(getAgentPdsUrl() || 'https://bsky.social').hostname;
-      const existingPdsForFailedLogin = this.get().atprotoPdsUrls[failedLoginIdentifier];
+      const failedLoginIdentifier = sessionData?.did || identifier
+      const pdsHostForFailedLogin = new URL(getAgentPdsUrl() || 'https://bsky.social').hostname
+      const existingPdsForFailedLogin = this.get().atprotoPdsUrls[failedLoginIdentifier]
 
       if (!existingPdsForFailedLogin && pdsHostForFailedLogin) {
         // Store the PDS URL even if login failed, so user doesn't have to re-enter it
         // Useful if only password was wrong.
-        const newAtprotoPdsUrls = { ...this.get().atprotoPdsUrls };
-        newAtprotoPdsUrls[failedLoginIdentifier] = getAgentPdsUrl(); // Store PDS for the identifier used
-        this.set({ atprotoPdsUrls: newAtprotoPdsUrls });
-        console.log(`[Store Mixin] Saved PDS URL ${getAgentPdsUrl()} for identifier ${failedLoginIdentifier} despite login failure.`);
+        const newAtprotoPdsUrls = { ...this.get().atprotoPdsUrls }
+        newAtprotoPdsUrls[failedLoginIdentifier] = getAgentPdsUrl() // Store PDS for the identifier used
+        this.set({ atprotoPdsUrls: newAtprotoPdsUrls })
+        console.log(`[Store Mixin] Saved PDS URL ${getAgentPdsUrl()} for identifier ${failedLoginIdentifier} despite login failure.`)
       }
       this.set({ isLoading: false, error: err.message, isAtprotoSessionActive: false })
       throw err
@@ -89,13 +98,18 @@ export function atprotoMixins (Store) {
     this.set({ isLoading: true })
     try {
       await atprotoAPI.logout() // Changed to atprotoAPI.logout
-      console.log(`[Store Mixin] atprotoLogout API call finished.`)
+      console.log('[Store Mixin] atprotoLogout API call finished.')
 
       const newAtprotoSessions = { ...this.get().atprotoSessions }
       if (currentDid) {
         delete newAtprotoSessions[currentDid]
         console.log(`[Store Mixin] Removed session for ${currentDid} from store.`)
       }
+
+      const pdsHost = new URL(getAgentPdsUrl()).hostname
+      const vcObj = { ...this.get().verifyCredentials }
+      delete vcObj[pdsHost]
+      await setInstanceVerifyCredentials(pdsHost, null)
 
       this.set({
         atprotoSessions: newAtprotoSessions,
@@ -105,6 +119,7 @@ export function atprotoMixins (Store) {
         error: null,
         currentAccountProtocol: null,
         currentInstance: (this.get().currentAccountProtocol !== 'atproto' ? this.get().currentInstance : null), // Null out currentInstance if it was this ATP account
+        verifyCredentials: vcObj
       })
       console.log('[Store Mixin] Store updated after successful atproto logout.')
     } catch (err) {
@@ -126,8 +141,8 @@ export function atprotoMixins (Store) {
         const pdsHostname = new URL(getAgentPdsUrl()).hostname // agent's current PDS
         const storedPdsUrlForUser = this.get().atprotoPdsUrls[session.did]
         if (storedPdsUrlForUser && getAgentPdsUrl() !== storedPdsUrlForUser) {
-            console.log(`[Store Mixin] Resumed session for ${session.did}, PDS mismatch. Agent: ${getAgentPdsUrl()}, Store: ${storedPdsUrlForUser}. Setting agent PDS to stored value.`)
-            setAgentPdsUrl(storedPdsUrlForUser)
+          console.log(`[Store Mixin] Resumed session for ${session.did}, PDS mismatch. Agent: ${getAgentPdsUrl()}, Store: ${storedPdsUrlForUser}. Setting agent PDS to stored value.`)
+          setAgentPdsUrl(storedPdsUrlForUser)
         }
 
         // Attempt to fetch profile from DB, then from network if not found or stale
@@ -139,6 +154,10 @@ export function atprotoMixins (Store) {
             if (profileFromNet && profileFromNet.data) {
               await setAtprotoAccount(pdsHostname, profileFromNet.data)
               userProfile = profileFromNet.data
+              const transformed = transformProfileViewToEnaforeAccount(profileFromNet.data, pdsHostname)
+              await setInstanceVerifyCredentials(pdsHostname, transformed)
+              const vcu = { ...this.get().verifyCredentials, [pdsHostname]: transformed }
+              this.set({ verifyCredentials: vcu })
               console.log(`[Store Mixin] Fetched and stored profile for ${session.did} from network.`)
             }
           } catch (profileError) {
@@ -146,6 +165,10 @@ export function atprotoMixins (Store) {
           }
         } else {
           console.log(`[Store Mixin] Profile for ${session.did} found in DB.`)
+          const transformed = transformProfileViewToEnaforeAccount(userProfile, pdsHostname)
+          await setInstanceVerifyCredentials(pdsHostname, transformed)
+          const vce = { ...this.get().verifyCredentials, [pdsHostname]: transformed }
+          this.set({ verifyCredentials: vce })
         }
         // session object from resumeAppSessionApi already contains { did, handle, email, accessJwt, refreshJwt }
         // userProfile contains { did, handle, displayName, description, avatar, etc. }
@@ -155,15 +178,15 @@ export function atprotoMixins (Store) {
         const currentSessions = this.get().atprotoSessions
         const currentPdsUrls = this.get().atprotoPdsUrls
 
-        let changes = {}
+        const changes = {}
         // Ensure the session object from API is in the store
         if (!currentSessions[session.did] || JSON.stringify(currentSessions[session.did]) !== JSON.stringify(session)) {
-            changes.atprotoSessions = {...currentSessions, [session.did]: session }
+          changes.atprotoSessions = { ...currentSessions, [session.did]: session }
         }
         // Ensure PDS URL is in the store
         const agentPds = getAgentPdsUrl()
         if (agentPds && (!currentPdsUrls[session.did] || currentPdsUrls[session.did] !== agentPds)) {
-            changes.atprotoPdsUrls = {...currentPdsUrls, [session.did]: agentPds}
+          changes.atprotoPdsUrls = { ...currentPdsUrls, [session.did]: agentPds }
         }
 
         this.set({
@@ -175,7 +198,7 @@ export function atprotoMixins (Store) {
           currentAccountProtocol: 'atproto', // Set current protocol
           currentInstance: new URL(getAgentPdsUrl()).hostname, // Set currentInstance to PDS hostname
           // Clear potentially conflicting AP state
-          currentRegisteredInstanceName: null,
+          currentRegisteredInstanceName: null
         })
         console.log(`[Store Mixin] Store updated after session resume. Current DID: ${session.did}, PDS: ${getAgentPdsUrl()}`)
         return session // This is the session object from auth, not the profile
@@ -184,7 +207,7 @@ export function atprotoMixins (Store) {
         this.set({
           currentAtprotoSessionDid: null,
           isAtprotoSessionActive: false,
-          isLoading: false,
+          isLoading: false
           // Do not null out currentInstance here, an AP session might still be active
         })
         return null
@@ -219,7 +242,7 @@ export function atprotoMixins (Store) {
     // We need to fetch the profile from the database.
 
     const pdsHostname = new URL(getAgentPdsUrl() || this.get().atprotoPdsUrls[did] || 'https://bsky.social').hostname
-    let userProfile = await getAtprotoAccount(pdsHostname, did)
+    const userProfile = await getAtprotoAccount(pdsHostname, did)
 
     if (!userProfile) {
       console.warn(`[Store Mixin] getCurrentAtprotoUser: Profile for DID ${did} not found in DB. May need to fetch from network if agent is active.`)
@@ -230,15 +253,15 @@ export function atprotoMixins (Store) {
     }
 
     // Construct the user object for UI, prioritizing DB profile data, fallback to session data.
-    const displayName = userProfile?.displayName || session.handle;
-    const avatar = userProfile?.avatar || null; // Prefer profile avatar
+    const displayName = userProfile?.displayName || session.handle
+    const avatar = userProfile?.avatar || null // Prefer profile avatar
     const userForUI = {
       id: session.did,
       did: session.did,
       username: session.handle, // From session (guaranteed)
-      handle: session.handle,   // From session
-      displayName: displayName,
-      avatar: avatar,
+      handle: session.handle, // From session
+      displayName,
+      avatar,
       // From profile if available
       description: userProfile?.description || '',
       followersCount: userProfile?.followersCount || 0,
@@ -270,7 +293,7 @@ export function atprotoMixins (Store) {
         isBlockingThem: !!userProfile?.viewer?.blocking,
         isBlockedByThem: !!userProfile?.viewer?.blockedBy,
         isFollowing: !!userProfile?.viewer?.following,
-        isFollowedBy: !!userProfile?.viewer?.followedBy,
+        isFollowedBy: !!userProfile?.viewer?.followedBy
       },
 
       // Raw data for debugging or more detailed views
@@ -291,14 +314,14 @@ export function atprotoMixins (Store) {
 
     const pdsHostname = new URL(getAgentPdsUrl()).hostname
     let cursorToUse = cursor || this.get().atprotoNotificationsCursor
-    const notifFeedIdentifier = 'notifications_all'; // Stable key for notifications feed cursor
+    const notifFeedIdentifier = 'notifications_all' // Stable key for notifications feed cursor
 
     if (!cursorToUse && typeof cursor !== 'string') { // Initial fetch or refresh, try DB
-        const dbCursor = await database.getAtprotoFeedCursor(pdsHostname, notifFeedIdentifier);
-        if (typeof dbCursor === 'string') {
-            console.log(`[Store Mixin] fetchAtprotoNotifications: Using cursor from DB for ${notifFeedIdentifier}: ${dbCursor}`);
-            cursorToUse = dbCursor;
-        }
+      const dbCursor = await database.getAtprotoFeedCursor(pdsHostname, notifFeedIdentifier)
+      if (typeof dbCursor === 'string') {
+        console.log(`[Store Mixin] fetchAtprotoNotifications: Using cursor from DB for ${notifFeedIdentifier}: ${dbCursor}`)
+        cursorToUse = dbCursor
+      }
     }
 
     console.log(`[Store Mixin] fetchAtprotoNotifications called. DID: ${currentDid}, Limit: ${limit}, Cursor: ${cursorToUse}`)
@@ -311,8 +334,8 @@ export function atprotoMixins (Store) {
       await setAtprotoNotifications(pdsHostname, fetchedNotifications)
 
       // Save the new cursor to DB and Svelte store
-      await database.setAtprotoFeedCursor(pdsHostname, notifFeedIdentifier, newApiCursor);
-      console.log(`[Store Mixin] fetchAtprotoNotifications: Stored new cursor for ${notifFeedIdentifier} (DB): ${newApiCursor}`);
+      await database.setAtprotoFeedCursor(pdsHostname, notifFeedIdentifier, newApiCursor)
+      console.log(`[Store Mixin] fetchAtprotoNotifications: Stored new cursor for ${notifFeedIdentifier} (DB): ${newApiCursor}`)
 
       // Update store state
       const existingNotifications = cursorToUse ? this.get().atprotoNotifications : [] // If cursorToUse had a value, append. Else, replace.
@@ -323,8 +346,8 @@ export function atprotoMixins (Store) {
 
       this.set({
         atprotoNotifications: uniqueNotifications,
-        atprotoNotificationsCursor: newCursor || null, // Store the new cursor
-        atprotoNotificationsLoading: false,
+        atprotoNotificationsCursor: newApiCursor || null, // Store the new cursor
+        atprotoNotificationsLoading: false
       })
 
       // Optionally, update unread count after fetching
@@ -332,7 +355,7 @@ export function atprotoMixins (Store) {
       // Or, if listNotifications also implies "read up to this point", update seen.
       // For now, unread count is separate.
 
-      console.log(`[Store Mixin] Fetched ${fetchedNotifications.length} ATProto notifications. New cursor: ${newCursor}. Total in store: ${uniqueNotifications.length}`)
+      console.log(`[Store Mixin] Fetched ${fetchedNotifications.length} ATProto notifications. New cursor: ${newApiCursor}. Total in store: ${uniqueNotifications.length}`)
     } catch (err) {
       console.error('[Store Mixin] fetchAtprotoNotifications error:', err.message, err)
       this.set({ atprotoNotificationsLoading: false, atprotoNotificationsError: err.message })
@@ -375,37 +398,37 @@ export function atprotoMixins (Store) {
   // where full status objects are stored (e.g., different `timelineData_timelineItemSummaries[instance][timeline]` arrays,
   // or a potential central cache of fully hydrated posts if Enafore uses one).
   // For now, it focuses on `timelineData_timelineItemSummaries`.
-  function _updateAtprotoStatusInAllTimelines(storeInstance, postUri, updateFn) {
-    const storeState = storeInstance.get();
-    let changed = false;
-    const keysToUpdate = []; // Collect keys of timelines that changed to set them specifically
+  function _updateAtprotoStatusInAllTimelines (storeInstance, postUri, updateFn) {
+    const storeState = storeInstance.get()
+    let changed = false
+    const keysToUpdate = [] // Collect keys of timelines that changed to set them specifically
 
     for (const stateKey in storeState) {
       // Check if this state property holds timeline data (could be timelineItemSummaries or other relevant structures)
       if (stateKey.startsWith('timelineData_') && typeof storeState[stateKey] === 'object' && storeState[stateKey] !== null) {
-        const timelineDataGroup = storeState[stateKey]; // e.g., storeState.timelineData_timelineItemSummaries
+        const timelineDataGroup = storeState[stateKey] // e.g., storeState.timelineData_timelineItemSummaries
 
         for (const instanceName in timelineDataGroup) { // instanceName here is pdsHostname for atproto
-          const instanceTimelines = timelineDataGroup[instanceName];
+          const instanceTimelines = timelineDataGroup[instanceName]
           if (typeof instanceTimelines === 'object' && instanceTimelines !== null) {
             for (const timelineName in instanceTimelines) {
-              let items = instanceTimelines[timelineName];
+              const items = instanceTimelines[timelineName]
               if (Array.isArray(items)) {
-                let itemUpdatedInThisTimeline = false;
+                let itemUpdatedInThisTimeline = false
                 const newItems = items.map(item => {
                   // Check if it's the target post and an atproto post
                   if (item && item.id === postUri && item.protocol === 'atproto') {
-                    changed = true;
-                    itemUpdatedInThisTimeline = true;
-                    return updateFn(item); // Apply the update function
+                    changed = true
+                    itemUpdatedInThisTimeline = true
+                    return updateFn(item) // Apply the update function
                   }
-                  return item;
-                });
+                  return item
+                })
                 if (itemUpdatedInThisTimeline) {
                   // This direct modification might not trigger Svelte's reactivity if items is a nested object.
                   // It's often better to do this.set({ [stateKey]: newTimelineDataGroup })
-                  timelineDataGroup[instanceName][timelineName] = newItems;
-                  keysToUpdate.push(stateKey);
+                  timelineDataGroup[instanceName][timelineName] = newItems
+                  keysToUpdate.push(stateKey)
                 }
               }
             }
@@ -415,207 +438,206 @@ export function atprotoMixins (Store) {
     }
     if (changed) {
       // To ensure reactivity, update the top-level keys that were modified.
-      const finalChanges = {};
-      new Set(keysToUpdate).forEach(key => finalChanges[key] = { ...storeState[key] });
+      const finalChanges = {}
+      new Set(keysToUpdate).forEach(key => finalChanges[key] = { ...storeState[key] })
       if (Object.keys(finalChanges).length > 0) {
-        storeInstance.set(finalChanges);
-        console.log(`[Store Mixin Helper] Updated status ${postUri} in relevant cached timelines.`);
+        storeInstance.set(finalChanges)
+        console.log(`[Store Mixin Helper] Updated status ${postUri} in relevant cached timelines.`)
       }
     }
   }
 
-
   Store.prototype.setPostLikeUri = function (pdsHostname, postUri, likeRecordUri, isLiked) {
     console.log(`[Store Mixin] setPostLikeUri for post ${postUri}. Like URI: ${likeRecordUri}, Is Liked: ${isLiked}`)
     _updateAtprotoStatusInAllTimelines(this, postUri, (status) => {
-      const newStatus = { ...status };
-      newStatus.myLikeUri = likeRecordUri;
-      newStatus.favorited = isLiked; // Keep Enafore's boolean flag consistent
+      const newStatus = { ...status }
+      newStatus.myLikeUri = likeRecordUri
+      newStatus.favorited = isLiked // Keep Enafore's boolean flag consistent
 
       // Optimistic count update
-      if (typeof newStatus.likeCount !== 'number') newStatus.likeCount = 0;
-      const oldIsLiked = status.myLikeUri && status.myLikeUri !== null; // Infer previous liked state
+      if (typeof newStatus.likeCount !== 'number') newStatus.likeCount = 0
+      const oldIsLiked = status.myLikeUri && status.myLikeUri !== null // Infer previous liked state
 
       if (isLiked && !oldIsLiked) {
-        newStatus.likeCount++;
+        newStatus.likeCount++
       } else if (!isLiked && oldIsLiked) {
-        newStatus.likeCount = Math.max(0, newStatus.likeCount - 1);
+        newStatus.likeCount = Math.max(0, newStatus.likeCount - 1)
       }
       // Ensure viewer state is updated if it exists (more aligned with bsky app.bsky.feed.defs#postView)
-      newStatus.viewer = { ...(newStatus.viewer || {}), like: likeRecordUri };
+      newStatus.viewer = { ...(newStatus.viewer || {}), like: likeRecordUri }
 
-      console.log(`[Store Mixin] Optimistically updated post ${postUri}: liked=${isLiked}, likeCount=${newStatus.likeCount}, likeUri=${likeRecordUri}`);
-      return newStatus;
-    });
+      console.log(`[Store Mixin] Optimistically updated post ${postUri}: liked=${isLiked}, likeCount=${newStatus.likeCount}, likeUri=${likeRecordUri}`)
+      return newStatus
+    })
 
     // Persist this change to the specific post in ATPROTO_POSTS_STORE
     getAtprotoPost(pdsHostname, postUri).then(postFromDb => {
       if (postFromDb) {
-        const updatedPostForDb = { ...postFromDb };
-        updatedPostForDb.myLikeUri = likeRecordUri;
-        updatedPostForDb.viewer = { ...(updatedPostForDb.viewer || {}), like: likeRecordUri };
-        if (typeof updatedPostForDb.likeCount !== 'number') updatedPostForDb.likeCount = 0;
+        const updatedPostForDb = { ...postFromDb }
+        updatedPostForDb.myLikeUri = likeRecordUri
+        updatedPostForDb.viewer = { ...(updatedPostForDb.viewer || {}), like: likeRecordUri }
+        if (typeof updatedPostForDb.likeCount !== 'number') updatedPostForDb.likeCount = 0
 
-        const oldIsLiked = postFromDb.myLikeUri && postFromDb.myLikeUri !== null;
+        const oldIsLiked = postFromDb.myLikeUri && postFromDb.myLikeUri !== null
         if (isLiked && !oldIsLiked) {
-          updatedPostForDb.likeCount++;
+          updatedPostForDb.likeCount++
         } else if (!isLiked && oldIsLiked) {
-          updatedPostForDb.likeCount = Math.max(0, updatedPostForDb.likeCount - 1);
+          updatedPostForDb.likeCount = Math.max(0, updatedPostForDb.likeCount - 1)
         }
         // Also update the 'favorited' boolean for consistency if it's stored in DB model
-        updatedPostForDb.favorited = isLiked;
+        updatedPostForDb.favorited = isLiked
 
         setAtprotoPost(pdsHostname, updatedPostForDb)
           .then(() => console.log(`[Store Mixin DB] Persisted like state for post ${postUri}`))
-          .catch(err => console.error(`[Store Mixin DB] Error persisting like state for post ${postUri}:`, err));
+          .catch(err => console.error(`[Store Mixin DB] Error persisting like state for post ${postUri}:`, err))
       } else {
         console.warn(`[Store Mixin DB] Post ${postUri} not found in DB for persisting like state.`)
       }
-    }).catch(err => console.error(`[Store Mixin DB] Error fetching post ${postUri} for persisting like state:`, err));
+    }).catch(err => console.error(`[Store Mixin DB] Error fetching post ${postUri} for persisting like state:`, err))
   }
 
   Store.prototype.setPostRepostUri = function (pdsHostname, postUri, repostRecordUri, isReposted) {
     console.log(`[Store Mixin] setPostRepostUri for post ${postUri}. Repost URI: ${repostRecordUri}, Is Reposted: ${isReposted}`)
     _updateAtprotoStatusInAllTimelines(this, postUri, (status) => {
-      const newStatus = { ...status };
-      newStatus.myRepostUri = repostRecordUri;
-      newStatus.reblogged = isReposted; // Keep Enafore's boolean flag consistent
+      const newStatus = { ...status }
+      newStatus.myRepostUri = repostRecordUri
+      newStatus.reblogged = isReposted // Keep Enafore's boolean flag consistent
 
-      if (typeof newStatus.repostCount !== 'number') newStatus.repostCount = 0;
-      const oldIsReposted = status.myRepostUri && status.myRepostUri !== null;
+      if (typeof newStatus.repostCount !== 'number') newStatus.repostCount = 0
+      const oldIsReposted = status.myRepostUri && status.myRepostUri !== null
 
       if (isReposted && !oldIsReposted) {
-        newStatus.repostCount++;
+        newStatus.repostCount++
       } else if (!isReposted && oldIsReposted) {
-        newStatus.repostCount = Math.max(0, newStatus.repostCount - 1);
+        newStatus.repostCount = Math.max(0, newStatus.repostCount - 1)
       }
-      newStatus.viewer = { ...(newStatus.viewer || {}), repost: repostRecordUri };
+      newStatus.viewer = { ...(newStatus.viewer || {}), repost: repostRecordUri }
 
-      console.log(`[Store Mixin] Optimistically updated post ${postUri}: reposted=${isReposted}, repostCount=${newStatus.repostCount}, repostUri=${repostRecordUri}`);
-      return newStatus;
-    });
+      console.log(`[Store Mixin] Optimistically updated post ${postUri}: reposted=${isReposted}, repostCount=${newStatus.repostCount}, repostUri=${repostRecordUri}`)
+      return newStatus
+    })
 
     // Persist this change to the specific post in ATPROTO_POSTS_STORE
     getAtprotoPost(pdsHostname, postUri).then(postFromDb => {
       if (postFromDb) {
-        const updatedPostForDb = { ...postFromDb };
-        updatedPostForDb.myRepostUri = repostRecordUri;
-        updatedPostForDb.viewer = { ...(updatedPostForDb.viewer || {}), repost: repostRecordUri };
-        if (typeof updatedPostForDb.repostCount !== 'number') updatedPostForDb.repostCount = 0;
+        const updatedPostForDb = { ...postFromDb }
+        updatedPostForDb.myRepostUri = repostRecordUri
+        updatedPostForDb.viewer = { ...(updatedPostForDb.viewer || {}), repost: repostRecordUri }
+        if (typeof updatedPostForDb.repostCount !== 'number') updatedPostForDb.repostCount = 0
 
-        const oldIsReposted = postFromDb.myRepostUri && postFromDb.myRepostUri !== null;
+        const oldIsReposted = postFromDb.myRepostUri && postFromDb.myRepostUri !== null
         if (isReposted && !oldIsReposted) {
-          updatedPostForDb.repostCount++;
+          updatedPostForDb.repostCount++
         } else if (!isReposted && oldIsReposted) {
-          updatedPostForDb.repostCount = Math.max(0, updatedPostForDb.repostCount - 1);
+          updatedPostForDb.repostCount = Math.max(0, updatedPostForDb.repostCount - 1)
         }
         // Also update the 'reblogged' boolean for consistency if it's stored in DB model
-        updatedPostForDb.reblogged = isReposted;
+        updatedPostForDb.reblogged = isReposted
 
         setAtprotoPost(pdsHostname, updatedPostForDb)
           .then(() => console.log(`[Store Mixin DB] Persisted repost state for post ${postUri}`))
-          .catch(err => console.error(`[Store Mixin DB] Error persisting repost state for post ${postUri}:`, err));
+          .catch(err => console.error(`[Store Mixin DB] Error persisting repost state for post ${postUri}:`, err))
       } else {
         console.warn(`[Store Mixin DB] Post ${postUri} not found in DB for persisting repost state.`)
       }
-    }).catch(err => console.error(`[Store Mixin DB] Error fetching post ${postUri} for persisting repost state:`, err));
+    }).catch(err => console.error(`[Store Mixin DB] Error fetching post ${postUri} for persisting repost state:`, err))
   }
 
   // --- Client-Side Bookmarks for ATProto ---
 
   Store.prototype.loadAtprotoBookmarks = async function () {
-    const currentDid = this.get().currentAtprotoSessionDid;
+    const currentDid = this.get().currentAtprotoSessionDid
     if (!currentDid || !this.get().isAtprotoSessionActive) {
-      console.warn('[Store Mixin] loadAtprotoBookmarks: No active ATProto session.');
-      this.set({ atprotoBookmarkedPostUris: new Set(), atprotoBookmarksList: [] });
-      return;
+      console.warn('[Store Mixin] loadAtprotoBookmarks: No active ATProto session.')
+      this.set({ atprotoBookmarkedPostUris: new Set(), atprotoBookmarksList: [] })
+      return
     }
-    const pdsHostname = new URL(getAgentPdsUrl() || this.get().atprotoPdsUrls[currentDid] || 'https://bsky.social').hostname;
-    console.log(`[Store Mixin] loadAtprotoBookmarks for PDS: ${pdsHostname}, User DID: ${currentDid}`);
-    this.set({ atprotoBookmarksLoading: true, atprotoBookmarksError: null });
+    const pdsHostname = new URL(getAgentPdsUrl() || this.get().atprotoPdsUrls[currentDid] || 'https://bsky.social').hostname
+    console.log(`[Store Mixin] loadAtprotoBookmarks for PDS: ${pdsHostname}, User DID: ${currentDid}`)
+    this.set({ atprotoBookmarksLoading: true, atprotoBookmarksError: null })
 
     try {
-      const bookmarks = await database.getAllAtprotoBookmarks(pdsHostname); // Load all, no limit for now
-      const uris = new Set(bookmarks.map(b => b.postUri));
+      const bookmarks = await database.getAllAtprotoBookmarks(pdsHostname) // Load all, no limit for now
+      const uris = new Set(bookmarks.map(b => b.postUri))
 
       // For atprotoBookmarksList, we'll store the raw {postUri, bookmarkedAt} from DB.
       // The UI component displaying the bookmarks list will be responsible for fetching
       // full post details for each URI using store.getOrFetchPostByUri or similar.
       this.set({
         atprotoBookmarkedPostUris: uris,
-        atprotoBookmarksList: bookmarks.sort((a,b) => new Date(b.bookmarkedAt).getTime() - new Date(a.bookmarkedAt).getTime()), // newest first
-        atprotoBookmarksLoading: false,
-      });
-      console.log(`[Store Mixin] Loaded ${uris.size} ATProto bookmark URIs.`);
+        atprotoBookmarksList: bookmarks.sort((a, b) => new Date(b.bookmarkedAt).getTime() - new Date(a.bookmarkedAt).getTime()), // newest first
+        atprotoBookmarksLoading: false
+      })
+      console.log(`[Store Mixin] Loaded ${uris.size} ATProto bookmark URIs.`)
     } catch (err) {
-      console.error('[Store Mixin] loadAtprotoBookmarks error:', err.message, err);
-      this.set({ atprotoBookmarksLoading: false, atprotoBookmarksError: err.message, atprotoBookmarkedPostUris: new Set(), atprotoBookmarksList: [] });
+      console.error('[Store Mixin] loadAtprotoBookmarks error:', err.message, err)
+      this.set({ atprotoBookmarksLoading: false, atprotoBookmarksError: err.message, atprotoBookmarkedPostUris: new Set(), atprotoBookmarksList: [] })
     }
-  };
+  }
 
   Store.prototype.addAtprotoBookmark = async function (postUri) {
-    const currentDid = this.get().currentAtprotoSessionDid;
-    if (!currentDid || !this.get().isAtprotoSessionActive || !postUri) return;
-    const pdsHostname = new URL(getAgentPdsUrl() || this.get().atprotoPdsUrls[currentDid] || 'https://bsky.social').hostname;
-    console.log(`[Store Mixin] addAtprotoBookmark for post: ${postUri}`);
+    const currentDid = this.get().currentAtprotoSessionDid
+    if (!currentDid || !this.get().isAtprotoSessionActive || !postUri) return
+    const pdsHostname = new URL(getAgentPdsUrl() || this.get().atprotoPdsUrls[currentDid] || 'https://bsky.social').hostname
+    console.log(`[Store Mixin] addAtprotoBookmark for post: ${postUri}`)
 
     try {
-      const newBookmarkRecord = await database.addAtprotoBookmark(pdsHostname, postUri);
+      const newBookmarkRecord = await database.addAtprotoBookmark(pdsHostname, postUri)
 
-      const newUris = new Set(this.get().atprotoBookmarkedPostUris || []);
-      newUris.add(postUri);
+      const newUris = new Set(this.get().atprotoBookmarkedPostUris || [])
+      newUris.add(postUri)
 
-      let newBookmarksList = [...(this.get().atprotoBookmarksList || [])];
+      const newBookmarksList = [...(this.get().atprotoBookmarksList || [])]
       if (!newBookmarksList.find(bm => bm.postUri === postUri)) {
-          newBookmarksList.unshift(newBookmarkRecord); // Add to top (newest)
-          newBookmarksList.sort((a,b) => new Date(b.bookmarkedAt).getTime() - new Date(a.bookmarkedAt).getTime());
+        newBookmarksList.unshift(newBookmarkRecord) // Add to top (newest)
+        newBookmarksList.sort((a, b) => new Date(b.bookmarkedAt).getTime() - new Date(a.bookmarkedAt).getTime())
       }
 
-      this.set({ atprotoBookmarkedPostUris: newUris, atprotoBookmarksList: newBookmarksList });
-      _updateAtprotoStatusInAllTimelines(this, postUri, (status) => ({ ...status, client_isBookmarked: true })); // Add client-side flag
-      console.log(`[Store Mixin] Added ATProto bookmark for ${postUri}.`);
-      toast.say('Bookmarked!'); // User feedback
+      this.set({ atprotoBookmarkedPostUris: newUris, atprotoBookmarksList: newBookmarksList })
+      _updateAtprotoStatusInAllTimelines(this, postUri, (status) => ({ ...status, client_isBookmarked: true })) // Add client-side flag
+      console.log(`[Store Mixin] Added ATProto bookmark for ${postUri}.`)
+      toast.say('Bookmarked!') // User feedback
     } catch (err) {
-      console.error('[Store Mixin] addAtprotoBookmark error:', err.message, err);
-      toast.say(`Failed to add bookmark: ${err.message}`);
+      console.error('[Store Mixin] addAtprotoBookmark error:', err.message, err)
+      toast.say(`Failed to add bookmark: ${err.message}`)
     }
-  };
+  }
 
   Store.prototype.removeAtprotoBookmark = async function (postUri) {
-    const currentDid = this.get().currentAtprotoSessionDid;
-    if (!currentDid || !this.get().isAtprotoSessionActive || !postUri) return;
-    const pdsHostname = new URL(getAgentPdsUrl() || this.get().atprotoPdsUrls[currentDid] || 'https://bsky.social').hostname;
-    console.log(`[Store Mixin] removeAtprotoBookmark for post: ${postUri}`);
+    const currentDid = this.get().currentAtprotoSessionDid
+    if (!currentDid || !this.get().isAtprotoSessionActive || !postUri) return
+    const pdsHostname = new URL(getAgentPdsUrl() || this.get().atprotoPdsUrls[currentDid] || 'https://bsky.social').hostname
+    console.log(`[Store Mixin] removeAtprotoBookmark for post: ${postUri}`)
 
     try {
-      await database.removeAtprotoBookmark(pdsHostname, postUri);
+      await database.removeAtprotoBookmark(pdsHostname, postUri)
 
-      const newUris = new Set(this.get().atprotoBookmarkedPostUris || []);
-      newUris.delete(postUri);
+      const newUris = new Set(this.get().atprotoBookmarkedPostUris || [])
+      newUris.delete(postUri)
 
-      const newList = (this.get().atprotoBookmarksList || []).filter(bm => bm.postUri !== postUri);
+      const newList = (this.get().atprotoBookmarksList || []).filter(bm => bm.postUri !== postUri)
 
-      this.set({ atprotoBookmarkedPostUris: newUris, atprotoBookmarksList: newList });
-      _updateAtprotoStatusInAllTimelines(this, postUri, (status) => ({ ...status, client_isBookmarked: false }));
-      console.log(`[Store Mixin] Removed ATProto bookmark for ${postUri}.`);
-      toast.say('Bookmark removed.'); // User feedback
+      this.set({ atprotoBookmarkedPostUris: newUris, atprotoBookmarksList: newList })
+      _updateAtprotoStatusInAllTimelines(this, postUri, (status) => ({ ...status, client_isBookmarked: false }))
+      console.log(`[Store Mixin] Removed ATProto bookmark for ${postUri}.`)
+      toast.say('Bookmark removed.') // User feedback
     } catch (err) {
-      console.error('[Store Mixin] removeAtprotoBookmark error:', err.message, err);
-      toast.say(`Failed to remove bookmark: ${err.message}`);
+      console.error('[Store Mixin] removeAtprotoBookmark error:', err.message, err)
+      toast.say(`Failed to remove bookmark: ${err.message}`)
     }
-  };
+  }
 
   Store.prototype.isPostAtprotoBookmarked = function (postUri) {
-    const uris = this.get().atprotoBookmarkedPostUris;
+    const uris = this.get().atprotoBookmarkedPostUris
     // Ensure uris is initialized (e.g. by loadAtprotoBookmarks) before checking
     if (uris === null && this.get().isAtprotoSessionActive && !this.get().atprotoBookmarksLoading) {
       // If uris is null (not loaded yet) and we are logged in and not currently loading, trigger a load.
       // This is a bit of a side-effect in a getter, might be better to ensure loadAtprotoBookmarks
       // is called on app init or when user logs into ATProto.
       // For now, just return false if not loaded to avoid triggering async load here.
-      console.warn("[Store Mixin] isPostAtprotoBookmarked: Bookmarks not loaded yet. Call loadAtprotoBookmarks on app/session init.")
-      return false;
+      console.warn('[Store Mixin] isPostAtprotoBookmarked: Bookmarks not loaded yet. Call loadAtprotoBookmarks on app/session init.')
+      return false
     }
-    return uris ? uris.has(postUri) : false;
-  };
+    return uris ? uris.has(postUri) : false
+  }
 }

--- a/src/routes/_store/store.js
+++ b/src/routes/_store/store.js
@@ -4,8 +4,6 @@ import { mixins } from './mixins/mixins.js'
 import { LocalStorageStore } from './LocalStorageStore.js'
 import { observe } from 'svelte-extras'
 import { isKaiOS } from '../_utils/userAgent/isKaiOS.js'
-import * as atprotoAPI from '../_api_atproto/auth.js' // ATProto auth functions
-import atprotoAgent from '../_api_atproto/agent.js' // ATProto agent
 
 const persistedState = {
   // ATProto specific persisted state
@@ -106,9 +104,9 @@ const nonPersistedState = {
   atprotoPostRepostersCache: {}, // Structure: { [postUri]: { users: [], cursor?: string, isLoading: false, error: null } }
   // ATProto Client-Side Bookmarks
   atprotoBookmarkedPostUris: null, // Set of bookmarked post URIs for quick lookups. Initialized from DB.
-  atprotoBookmarksList: [],      // Array of {postUri, bookmarkedAt, ?transformedPost} for UI display.
+  atprotoBookmarksList: [], // Array of {postUri, bookmarkedAt, ?transformedPost} for UI display.
   atprotoBookmarksLoading: false,
-  atprotoBookmarksError: null,
+  atprotoBookmarksError: null
 }
 
 const state = Object.assign({}, persistedState, nonPersistedState)


### PR DESCRIPTION
## Summary
- transform ProfileView to Enafore account format
- store verify credentials for ATProto accounts during login/resume
- clear verify credentials on atproto logout
- wire account profile transform

## Testing
- `npm run lint` *(fails: standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c0192ce44832b93bcc078d0c5b61b